### PR TITLE
Debug additions: color different logs; in debug mode and for errors always print full info

### DIFF
--- a/RemObjects.Train/API/Delphi.pas
+++ b/RemObjects.Train/API/Delphi.pas
@@ -220,14 +220,14 @@ begin
 
   var lTmp := new DelayedLogger();
   var lOutput := new StringBuilder;
-  aServices.Logger.LogMessage('Running: {0} {1}', lRootPath, sb.ToString);
+  aServices.Logger.LogCommand(lRootPath, sb.ToString);
 
   var lenvironment := new Environment();
   lenvironment.LoadSystem;
   lenvironment.Item['Path'] := lDelphi+';'+lenvironment.Item['Path'];
   var lenv: array of KeyValuePair<String,String> := lenvironment.Select(a->new KeyValuePair<String,String>(a.Key,a.Value.ToString)).ToArray;
 
-  var n := Shell.ExecuteProcess(lRootPath, sb.ToString, lPath,false ,
+  var lExitCode := Shell.ExecuteProcess(lRootPath, sb.ToString, lPath,false ,
   a-> begin
     if not String.IsNullOrEmpty(a) then begin
       lTmp.LogError(a);
@@ -241,14 +241,12 @@ begin
     end;
    end, lenv, nil);
 
-  if n <> 0 then
-    lTmp.LogOutputDump(lOutput.ToString, false)
-  else
-    lTmp.LogOutputDump(lOutput.ToString, true);
+  var lSuccess := (lExitCode = 0);
+  lTmp.LogOutputDump(lOutput.ToString, lSuccess);
 
   lTmp.Replay(aServices.Logger);
 
-  if n <> 0 then raise new Exception('Delphi failed');
+  if not lSuccess then raise new Exception('Delphi failed');
 end;
 
 class method DelphiPlugin.RebuildMultiPath(aServices: IApiRegistrationServices; ec: ExecutionContext; aDelphi, aInput, aPlatform: String): String;

--- a/RemObjects.Train/API/Delphi.pas
+++ b/RemObjects.Train/API/Delphi.pas
@@ -242,9 +242,9 @@ begin
    end, lenv, nil);
 
   if n <> 0 then
-    lTmp.LogMessage(lOutput.ToString)
+    lTmp.LogOutputDump(lOutput.ToString, false)
   else
-    lTmp.LogInfo(lOutput.ToString);
+    lTmp.LogOutputDump(lOutput.ToString, true);
 
   lTmp.Replay(aServices.Logger);
 

--- a/RemObjects.Train/API/EBuild.pas
+++ b/RemObjects.Train/API/EBuild.pas
@@ -128,7 +128,7 @@ type
                                                                                                       locking sb do sb.AppendLine(a);
                                                                                                       lLogger.LogError(a);
                                                                                                       if aServices.Engine.LiveOutput then
-                                                                                                        aServices.Engine.Logger.LogLive("(stderr) "+a);
+                                                                                                        aServices.Engine.Logger.LogCommandOutputError(a);
                                                                                                     end;
                                                                                                   end,
                                                                                               a-> begin
@@ -137,11 +137,11 @@ type
                                                                                                       if a:StartsWith("E:") then
                                                                                                         lLogger.LogError("Error: "+a);
                                                                                                       if aServices.Engine.LiveOutput then
-                                                                                                        aServices.Engine.Logger.LogLive(a);
+                                                                                                        aServices.Engine.Logger.LogCommandOutput(a);
                                                                                                     end;
                                                                                                   end, [], nil);
 
-        lLogger.LogInfo(sb.ToString);
+        lLogger.LogOutputDump(sb.ToString, lExitCode = 0);
         if lExitCode ≠ 0 then begin
 
           //var lErrors := new System.Text.StringBuilder;

--- a/RemObjects.Train/API/File.pas
+++ b/RemObjects.Train/API/File.pas
@@ -143,7 +143,7 @@ begin
       System.IO.File.Move(el, lTargetFN);
       lFiles .AppendLine(String.Format('Moved {0} to {1}', el,  lTargetFN));
     end;
-    aServices.Logger.LogInfo(lFiles.ToString);
+    aServices.Logger.LogCommand('file.move', lFiles.ToString);
     if lZero then raise new Exception('Zero files moved!');
     exit;
   end;
@@ -162,7 +162,7 @@ begin
 
     System.IO.File.Move(lVal, lVal2);
   end;
-  aServices.Logger.LogInfo(String.Format('Moved {0} to {1}', lVal,  lVal2));
+  aServices.Logger.LogCommand('file.move', String.Format('{0} to {1}', lVal,  lVal2));
 end;
 
 class method FilePlugin.File_Copy(aServices: IApiRegistrationServices; ec: ExecutionContext; aLeft, aRight: String; aRecurse: Boolean := false; aOverride: Boolean := true);
@@ -199,7 +199,7 @@ begin
 
     end;
 
-    aServices.Logger.LogInfo(lFiles.ToString);
+    aServices.Logger.LogCommand('file.copy', lFiles.ToString);
     if lZero then raise new Exception('Zero files copied!');
     exit;
   end;
@@ -217,7 +217,7 @@ begin
       raise new Exception(String.Format("Target file '{0}' already exists.", lVal2));
     RemObjects.Elements.RTL.File.CopyTo(lVal, lVal2, true);
   end;
-  //aServices.Logger.LogInfo(String.Format('Copied {0} to {1}', lVal,  lVal2));
+  aServices.Logger.LogCommand('file.copy', String.Format('{0} to {1}', lVal,  lVal2));
 end;
 
 class method FilePlugin.File_Delete(aServices: IApiRegistrationServices; ec: ExecutionContext; aFN: String; aRecurse: Boolean := false);
@@ -229,8 +229,10 @@ begin
   lVal := Path.Combine(lPath, lName);
 
   if lVal = nil then exit;
-  for each el in Find(lVal) do
+  for each el in Find(lVal) do begin
     System.IO.File.Delete(el);
+    aServices.Logger.LogCommand('file.remove', el);
+  end;
   if aRecurse then
     for each f in Directory.GetDirectories(Path.GetDirectoryName(lVal)) do
       File_Delete(aServices, ec, Path.Combine(f, Path.GetFileName(lVal)), true);
@@ -249,12 +251,14 @@ begin
   if not System.IO.Directory.Exists(Path.GetDirectoryName(lVal)) then
     Directory.CreateDirectory(Path.GetDirectoryName(lVal));
   System.IO.File.WriteAllText(lVal, aData);
+  aServices.Logger.LogCommand('file.write', lVal);
 end;
 
 class method FilePlugin.File_Append(aServices: IApiRegistrationServices; ec: ExecutionContext; aFN, aData:String);
 begin
   var lVal := aServices.ResolveWithBase(ec, aFN, true);
   System.IO.File.AppendAllText(lVal, aData);
+  aServices.Logger.LogCommand('file.append', lVal);
 end;
 
 class method FilePlugin.File_Exists(aServices: IApiRegistrationServices; ec: ExecutionContext; aFN: String): Boolean;
@@ -277,6 +281,7 @@ class method FilePlugin.Folder_Create(aServices: IApiRegistrationServices; ec: E
 begin
   var lVal := aServices.ResolveWithBase(ec, aFN);
   System.IO.Directory.CreateDirectory(lVal);
+  aServices.Logger.LogCommand('folder.create', lVal);
 end;
 
 class method FilePlugin.Folder_Delete(aServices: IApiRegistrationServices; ec: ExecutionContext; aFN: String; aRecurse: Boolean := true);
@@ -284,6 +289,7 @@ begin
   var lVal := aServices.ResolveWithBase(ec, aFN);
   if System.IO.Directory.Exists(lVal) then
   System.IO.Directory.Delete(lVal, aRecurse);
+  aServices.Logger.LogCommand('folder.remove', lVal);
 end;
 
 class method FilePlugin.Path_Combine(aServices: IApiRegistrationServices; ec: ExecutionContext; params args: array of String): String;
@@ -361,7 +367,7 @@ begin
   var lVal := aServices.ResolveWithBase(ec, aLeft);
   var lVal2 := aServices.ResolveWithBase(ec, aRight);
   System.IO.Directory.Move(lVal, lVal2);
-  aServices.Logger.LogMessage('Moved {0} to {1}', lVal, lVal2);
+  aServices.Logger.LogCommand('folder.move', String.Format('{0} to {1}', lVal, lVal2));
 end;
 
 class method FilePlugin.File_SetAttributes(aServices: IApiRegistrationServices; ec: ExecutionContext; aFileName: String; aFileFlagsOptions: FileFlagsOptions := nil);

--- a/RemObjects.Train/API/Logging.pas
+++ b/RemObjects.Train/API/Logging.pas
@@ -242,7 +242,8 @@ begin
         a.ToString()
       else
         'null';
-      if length(result) > 250 then
+      // Don't truncate in debug mode - users need full info when debugging
+      if (not LoggerSettings.ShowDebug) and (length(result) > 250) then
         result := result.Substring(0, 100)+"...";
     end).ToArray);
   var lNode := new XElement('action', new XAttribute('name', Filter(aScript)), new XAttribute('args', Filter(lArgsString)));

--- a/RemObjects.Train/API/Logging.pas
+++ b/RemObjects.Train/API/Logging.pas
@@ -18,6 +18,44 @@ uses
   DiscUtils.Iscsi;
 
 type
+  // Message type classification for semantic logging
+  LogMessageKind = public enum (
+    // Basic logging
+    Debug,              // DarkBlue - debug diagnostics
+    Message,            // Gray - normal Train messages
+    Warning,            // Yellow - warnings
+    Hint,               // Magenta - hints
+    Error,              // Red/DarkRed - errors
+
+    // Command execution
+    CommandOutput,      // White - stdout from command
+    CommandOutputError, // White with Red "(stderr)" prefix - stderr from command
+
+    // Output dumping
+    OutputDumpSuccess,  // White with "Output:" prefix - successful command output
+    OutputDumpError     // White with "Output:" prefix - failed command output
+  );
+
+  // Centralized color definitions
+  LogColors = public static class
+  public
+    // Core message types
+    class property Debug: ConsoleColor := ConsoleColor.DarkBlue;
+    class property Message: ConsoleColor := ConsoleColor.Gray;
+    class property Warning: ConsoleColor := ConsoleColor.Yellow;
+    class property Hint: ConsoleColor := ConsoleColor.Cyan;
+    class property Error: ConsoleColor := ConsoleColor.Red;
+    class property ErrorIgnored: ConsoleColor := ConsoleColor.DarkRed;
+
+    // Command execution
+    class property Command: ConsoleColor := ConsoleColor.Magenta;
+    class property CommandOutput: ConsoleColor := ConsoleColor.White;
+    class property StderrPrefix: ConsoleColor := ConsoleColor.Red;
+
+    // Function tracing
+    class property FunctionTrace: ConsoleColor := ConsoleColor.White;
+  end;
+
   [PluginRegistration]
   LoggingRegistration = public class(IPluginRegistration)
   private
@@ -45,6 +83,7 @@ type
 
   FailMode = public (No, Yes, Recovered, Unknown);
   ILogger = public interface
+    // Existing methods (for backwards compatibility)
     method LogError(s: String);
     method LogMessage(s: String);
     method LogWarning(s: String);
@@ -52,6 +91,16 @@ type
     method LogDebug(s: String);
     method LogInfo(s: String);
     method LogLive(s: String);
+
+    // New unified method
+    method Log(aKind: LogMessageKind; s: String);
+
+    // Specialized command logging
+    method LogCommand(aExecutable: String; aArguments: String);
+    method LogCommandOutput(s: String);
+    method LogCommandOutputError(s: String);
+    method LogOutputDump(s: String; aSuccess: Boolean);
+
     method Enter(aImportant: Boolean := false; aScript: String; params args: array of Object);
     method &Exit(aImportant: Boolean := false; aScript: String; aFailMode: FailMode; aResult: Object := nil);
     method &Write;
@@ -74,6 +123,11 @@ type
     method LogDebug(s: String);locked;
     method LogInfo(s: String); locked;
     method LogLive(s: String); locked;
+    method Log(aKind: LogMessageKind; s: String); locked;
+    method LogCommand(aExecutable: String; aArguments: String); locked;
+    method LogCommandOutput(s: String); locked;
+    method LogCommandOutputError(s: String); locked;
+    method LogOutputDump(s: String; aSuccess: Boolean); locked;
     method Enter(aImportant: Boolean := false; aScript: String; params args: array of Object);locked;
     method &Exit(aImportant: Boolean := false; aScript: String; aFailMode: FailMode; aResult: Object);locked;
     property InIgnore: Boolean read get_InIgnore    write set_InIgnore;
@@ -98,6 +152,11 @@ type
     method LogDebug(s: String);locked;
     method LogInfo(s: String); locked;
     method LogLive(s: String); empty;
+    method Log(aKind: LogMessageKind; s: String); locked;
+    method LogCommand(aExecutable: String; aArguments: String); locked;
+    method LogCommandOutput(s: String); locked;
+    method LogCommandOutputError(s: String); locked;
+    method LogOutputDump(s: String; aSuccess: Boolean); locked;
     method Enter(aImportant: Boolean := false; aScript: String; params args: array of Object);locked;
     method &Exit(aImportant: Boolean := false; aScript: String; aFailMode: FailMode; aResult: Object);locked;
     class method MyToString(s: Object): String;
@@ -390,6 +449,31 @@ end;
 method MultiLogger.LogLive(s: String);
 begin
   Loggers.ForEach(a -> a.LogLive(s) );
+end;
+
+method MultiLogger.Log(aKind: LogMessageKind; s: String);
+begin
+  Loggers.ForEach(a -> a.Log(aKind, s));
+end;
+
+method MultiLogger.LogCommand(aExecutable: String; aArguments: String);
+begin
+  Loggers.ForEach(a -> a.LogCommand(aExecutable, aArguments));
+end;
+
+method MultiLogger.LogCommandOutput(s: String);
+begin
+  Loggers.ForEach(a -> a.LogCommandOutput(s));
+end;
+
+method MultiLogger.LogCommandOutputError(s: String);
+begin
+  Loggers.ForEach(a -> a.LogCommandOutputError(s));
+end;
+
+method MultiLogger.LogOutputDump(s: String; aSuccess: Boolean);
+begin
+  Loggers.ForEach(a -> a.LogOutputDump(s, aSuccess));
 end;
 
 method MultiLogger.Enter(aImportant: Boolean := false; aScript: String; params args: array of Object);

--- a/RemObjects.Train/API/Logging.pas
+++ b/RemObjects.Train/API/Logging.pas
@@ -376,6 +376,37 @@ begin
   LogMessage(s);
 end;
 
+method BaseXmlLogger.Log(aKind: LogMessageKind; s: String);
+begin
+  fXmlData.Add(new XElement('message', new XAttribute('kind', aKind.ToString.ToLowerInvariant), Filter(s)));
+end;
+
+method BaseXmlLogger.LogCommand(aExecutable: String; aArguments: String);
+begin
+  var lMessage := Filter(aExecutable);
+  if not String.IsNullOrEmpty(aArguments) then
+    lMessage := lMessage + ' ' + Filter(aArguments);
+  fXmlData.Add(new XElement('message', new XAttribute('kind', 'command'), lMessage));
+end;
+
+method BaseXmlLogger.LogCommandOutput(s: String);
+begin
+  fXmlData.Add(new XElement('message', new XAttribute('kind', 'commandOutput'), Filter(s)));
+end;
+
+method BaseXmlLogger.LogCommandOutputError(s: String);
+begin
+  fXmlData.Add(new XElement('message', new XAttribute('kind', 'commandOutput'), new XAttribute('stream', 'stderr'), Filter(s)));
+end;
+
+method BaseXmlLogger.LogOutputDump(s: String; aSuccess: Boolean);
+begin
+  fXmlData.Add(new XElement('message',
+    new XAttribute('kind', 'output'),
+    new XAttribute('success', if aSuccess then 'true' else 'false'),
+    Filter(s)));
+end;
+
 class method BaseXmlLogger.Filter(s: String): String;
 begin
   if s = nil then exit '';

--- a/RemObjects.Train/API/MSBuild.pas
+++ b/RemObjects.Train/API/MSBuild.pas
@@ -135,7 +135,7 @@ begin
   var lTmp := new DelayedLogger();
   aServices.Logger.LogCommand(lbuild, sb.ToString);
   var lOutput := new StringBuilder;
-  var n := Shell.ExecuteProcess(lbuild, sb.ToString, nil,false ,
+  var lExitCode := Shell.ExecuteProcess(lbuild, sb.ToString, nil,false ,
   a-> begin
     if not String.IsNullOrEmpty(a) then begin
       lTmp.LogError(a);
@@ -153,14 +153,12 @@ begin
     end;
    end, nil, nil);
 
-  if n <> 0 then
-    lTmp.LogOutputDump(lOutput.ToString, false)
-  else
-    lTmp.LogOutputDump(lOutput.ToString, true);
+  var lSuccess := (lExitCode = 0);
+  lTmp.LogOutputDump(lOutput.ToString, lSuccess);
 
   lTmp.Replay(aServices.Logger);
 
-  if n <> 0 then raise new Exception('MSBuild failed');
+  if not lSuccess then raise new Exception('MSBuild failed');
 end;
 
 class method MSBuildPlugin.MSBuildBuild(aServices: IApiRegistrationServices; ec: ExecutionContext; aProject: String; aOptions: MSBuildOptions);
@@ -184,7 +182,7 @@ begin
   var lTmp := new DelayedLogger();
   aServices.Logger.LogCommand(lbuild, sb.ToString);
   var lOutput := new StringBuilder;
-  var n := Shell.ExecuteProcess(lbuild, sb.ToString, nil,false ,
+  var lExitCode := Shell.ExecuteProcess(lbuild, sb.ToString, nil,false ,
   a-> begin
     if not String.IsNullOrEmpty(a) then begin
       lTmp.LogError(a);
@@ -202,14 +200,12 @@ begin
     end;
    end, nil, nil);
 
-  if n <> 0 then
-    lTmp.LogOutputDump(lOutput.ToString, false)
-  else
-    lTmp.LogOutputDump(lOutput.ToString, true);
+  var lSuccess := (lExitCode = 0);
+  lTmp.LogOutputDump(lOutput.ToString, lSuccess);
 
   lTmp.Replay(aServices.Logger);
 
-  if n <> 0 then raise new Exception('MSBuild failed');
+  if not lSuccess then raise new Exception('MSBuild failed');
 end;
 
 class method MSBuildPlugin.MSBuildRebuild(aServices: IApiRegistrationServices; ec: ExecutionContext; aProject: String; aOptions: MSBuildOptions);
@@ -235,7 +231,7 @@ begin
   var lTmp := new DelayedLogger();
   aServices.Logger.LogCommand(lbuild, sb.ToString);
   var lOutput := new StringBuilder;
-  var n := Shell.ExecuteProcess(lbuild, sb.ToString, nil,false ,
+  var lExitCode := Shell.ExecuteProcess(lbuild, sb.ToString, nil,false ,
   a-> begin
     if not String.IsNullOrEmpty(a) then begin
       lTmp.LogError(a);
@@ -253,14 +249,12 @@ begin
     end;
    end, nil, nil);
 
-  if n <> 0 then
-    lTmp.LogOutputDump(lOutput.ToString, false)
-  else
-    lTmp.LogOutputDump(lOutput.ToString, true);
+  var lSuccess := (lExitCode = 0);
+  lTmp.LogOutputDump(lOutput.ToString, lSuccess);
 
   lTmp.Replay(aServices.Logger);
 
-  if n <> 0 then raise new Exception('MSBuild failed');
+  if not lSuccess then raise new Exception('MSBuild failed');
 end;
 
 class method MSBuildPlugin.MSBuildUpdateAssemblyVersion(aServices: IApiRegistrationServices; ec: ExecutionContext;
@@ -327,7 +321,7 @@ begin
   var lTmp := new DelayedLogger();
   aServices.Logger.LogCommand(lbuild, sb.ToString);
   var lOutput := new StringBuilder;
-  var n := Shell.ExecuteProcess(lbuild, sb.ToString, nil,false ,
+  var lExitCode := Shell.ExecuteProcess(lbuild, sb.ToString, nil,false ,
   a-> begin
     if not String.IsNullOrEmpty(a) then begin
       lTmp.LogError(a);
@@ -346,14 +340,12 @@ begin
     end;
    end, nil, nil);
 
-  if n <> 0 then
-    lTmp.LogOutputDump(lOutput.ToString, false)
-  else
-    lTmp.LogOutputDump(lOutput.ToString, true);
+  var lSuccess := (lExitCode = 0);
+  lTmp.LogOutputDump(lOutput.ToString, lSuccess);
 
   lTmp.Replay(aServices.Logger);
 
-  if n <> 0 then raise new Exception('MSBuild failed');
+  if not lSuccess then raise new Exception('MSBuild failed');
 
 end;
 

--- a/RemObjects.Train/API/MSBuild.pas
+++ b/RemObjects.Train/API/MSBuild.pas
@@ -133,7 +133,7 @@ begin
   end;
 
   var lTmp := new DelayedLogger();
-  aServices.Logger.LogMessage('Running: {0} {1}', lbuild, sb.ToString);
+  aServices.Logger.LogCommand(lbuild, sb.ToString);
   var lOutput := new StringBuilder;
   var n := Shell.ExecuteProcess(lbuild, sb.ToString, nil,false ,
   a-> begin
@@ -141,7 +141,7 @@ begin
       lTmp.LogError(a);
       locking lOutput do lOutput.AppendLine(a);
       if fServices.Engine.LiveOutput then
-        fServices.Engine.Logger.LogLive("(stderr) "+a);
+        fServices.Engine.Logger.LogCommandOutputError(a);
     end;
    end ,a-> begin
     if not String.IsNullOrEmpty(a) then begin
@@ -149,14 +149,14 @@ begin
         lTmp.LogError(a);
       locking lOutput do lOutput.AppendLine(a);
       if fServices.Engine.LiveOutput then
-        fServices.Engine.Logger.LogLive(a);
+        fServices.Engine.Logger.LogCommandOutput(a);
     end;
    end, nil, nil);
 
   if n <> 0 then
-    lTmp.LogMessage(lOutput.ToString)
+    lTmp.LogOutputDump(lOutput.ToString, false)
   else
-    lTmp.LogInfo(lOutput.ToString);
+    lTmp.LogOutputDump(lOutput.ToString, true);
 
   lTmp.Replay(aServices.Logger);
 
@@ -182,7 +182,7 @@ begin
     sb.Append(' '+aOptions.extraArgs);
   end;
   var lTmp := new DelayedLogger();
-  aServices.Logger.LogMessage('Running: {0} {1}', lbuild, sb.ToString);
+  aServices.Logger.LogCommand(lbuild, sb.ToString);
   var lOutput := new StringBuilder;
   var n := Shell.ExecuteProcess(lbuild, sb.ToString, nil,false ,
   a-> begin
@@ -190,7 +190,7 @@ begin
       lTmp.LogError(a);
       locking lOutput do lOutput.AppendLine(a);
       if fServices.Engine.LiveOutput then
-        fServices.Engine.Logger.LogLive("(stderr) "+a);
+        fServices.Engine.Logger.LogCommandOutputError(a);
     end;
    end ,a-> begin
     if not String.IsNullOrEmpty(a) then begin
@@ -198,14 +198,14 @@ begin
         lTmp.LogError(a);
       locking lOutput do lOutput.AppendLine(a);
       if fServices.Engine.LiveOutput then
-        fServices.Engine.Logger.LogLive(a);
+        fServices.Engine.Logger.LogCommandOutput(a);
     end;
    end, nil, nil);
 
   if n <> 0 then
-    lTmp.LogMessage(lOutput.ToString)
+    lTmp.LogOutputDump(lOutput.ToString, false)
   else
-    lTmp.LogInfo(lOutput.ToString);
+    lTmp.LogOutputDump(lOutput.ToString, true);
 
   lTmp.Replay(aServices.Logger);
 
@@ -233,7 +233,7 @@ begin
   end;
 
   var lTmp := new DelayedLogger();
-  aServices.Logger.LogMessage('Running: {0} {1}', lbuild, sb.ToString);
+  aServices.Logger.LogCommand(lbuild, sb.ToString);
   var lOutput := new StringBuilder;
   var n := Shell.ExecuteProcess(lbuild, sb.ToString, nil,false ,
   a-> begin
@@ -241,7 +241,7 @@ begin
       lTmp.LogError(a);
       locking lOutput do lOutput.AppendLine(a);
       if fServices.Engine.LiveOutput then
-        fServices.Engine.Logger.LogLive("(stderr) "+a);
+        fServices.Engine.Logger.LogCommandOutputError(a);
     end;
    end ,a-> begin
     if not String.IsNullOrEmpty(a) then begin
@@ -249,14 +249,14 @@ begin
         lTmp.LogError(a);
       locking lOutput do lOutput.AppendLine(a);
       if fServices.Engine.LiveOutput then
-        fServices.Engine.Logger.LogLive(a);
+        fServices.Engine.Logger.LogCommandOutput(a);
     end;
    end, nil, nil);
 
   if n <> 0 then
-    lTmp.LogMessage(lOutput.ToString)
+    lTmp.LogOutputDump(lOutput.ToString, false)
   else
-    lTmp.LogInfo(lOutput.ToString);
+    lTmp.LogOutputDump(lOutput.ToString, true);
 
   lTmp.Replay(aServices.Logger);
 
@@ -325,7 +325,7 @@ begin
   end;
 
   var lTmp := new DelayedLogger();
-  aServices.Logger.LogMessage('Running: {0} {1}', lbuild, sb.ToString);
+  aServices.Logger.LogCommand(lbuild, sb.ToString);
   var lOutput := new StringBuilder;
   var n := Shell.ExecuteProcess(lbuild, sb.ToString, nil,false ,
   a-> begin
@@ -333,7 +333,7 @@ begin
       lTmp.LogError(a);
       locking lOutput do lOutput.AppendLine(a);
       if fServices.Engine.LiveOutput then
-        fServices.Engine.Logger.LogLive("(stderr) "+a);
+        fServices.Engine.Logger.LogCommandOutputError(a);
     end;
    end ,a-> begin
     if not String.IsNullOrEmpty(a) then begin
@@ -342,14 +342,14 @@ begin
       locking lOutput do lOutput.AppendLine(a);
       writeLn(fServices.Engine.Logger);
       if fServices.Engine.LiveOutput then
-        fServices.Engine.Logger.LogLive(a);
+        fServices.Engine.Logger.LogCommandOutput(a);
     end;
    end, nil, nil);
 
   if n <> 0 then
-    lTmp.LogMessage(lOutput.ToString)
+    lTmp.LogOutputDump(lOutput.ToString, false)
   else
-    lTmp.LogInfo(lOutput.ToString);
+    lTmp.LogOutputDump(lOutput.ToString, true);
 
   lTmp.Replay(aServices.Logger);
 

--- a/RemObjects.Train/API/Shell.pas
+++ b/RemObjects.Train/API/Shell.pas
@@ -90,7 +90,7 @@ begin
                                                                                                 if assigned(a) then begin
                                                                                                   locking sb do sb.AppendLine(a);
                                                                                                   if fEngine.Engine.LiveOutput then
-                                                                                                    fEngine.Engine.Logger.LogLive("(stderr) "+a);
+                                                                                                    fEngine.Engine.Logger.LogCommandOutputError(a);
                                                                                                   if assigned(lCaptureFunc) then begin
                                                                                                     try
                                                                                                       lCaptureFunc.Call(ec, a);
@@ -103,7 +103,7 @@ begin
                                                                                                 locking sb do sb.AppendLine(a);
                                                                                                 if assigned(a) then begin
                                                                                                   if fEngine.Engine.LiveOutput then
-                                                                                                    fEngine.Engine.Logger.LogLive(a);
+                                                                                                    fEngine.Engine.Logger.LogCommandOutput(a);
                                                                                                   if assigned(lCaptureFunc) then begin
                                                                                                     try
                                                                                                       lCaptureFunc.Call(ec, a);
@@ -124,11 +124,11 @@ begin
       if not errorOK then begin
         var lErr := 'Failed with error code: '+lExit;
         fEngine.Engine.Logger.LogError(lErr);
-        locking sb do fEngine.Engine.Logger.LogMessage('Output: '#13#10+sb.ToString);
+        locking sb do fEngine.Engine.Logger.LogOutputDump(sb.ToString, false);
         raise new Exception(lErr);
       end;
     end;
-    locking sb do fEngine.Engine.Logger.LogInfo('Output: '#13#10+sb.ToString);
+    locking sb do fEngine.Engine.Logger.LogOutputDump(sb.ToString, true);
     lFail := false;
     if lCaptureMode then  begin
       locking sb do exit sb.ToString()
@@ -187,7 +187,7 @@ begin
                                                                                             a-> begin
                                                                                                   locking sb do sb.AppendLine(a);
                                                                                                 end, lEnv.ToArray, lTimeout, lProc);
-      locking sb do lLogger.LogInfo('Output: '#13#10+sb.ToString);
+      locking sb do lLogger.LogOutputDump(sb.ToString, lExit = 0);
       if lProc.Killed then exit;
       if 0 <> lExit then begin
         var lErr := 'Failed with error code: '+lExit;
@@ -242,7 +242,7 @@ begin
     end, a-> begin
       locking sb do sb.AppendLine(a)
     end, nil, nil);
-    locking sb do fEngine.Engine.Logger.LogInfo('Output: '#13#10+sb.ToString);
+    locking sb do fEngine.Engine.Logger.LogOutputDump(sb.ToString, lExit = 0);
     if 0 <> lExit then begin
       var lErr := 'Failed with error code: '+lExit;
       fEngine.Engine.Logger.LogError(lErr);

--- a/RemObjects.Train/API/Xcode.pas
+++ b/RemObjects.Train/API/Xcode.pas
@@ -96,11 +96,11 @@ begin
    end, nil, nil);
 
   if n <> 0 then begin
-    aServices.Logger.LogMessage(lOutput.ToString);
+    aServices.Logger.LogOutputDump(lOutput.ToString, false);
     for each el in lErrors do
       aServices.Logger.LogError(el);
   end else
-    aServices.Logger.LogDebug(lOutput.ToString);
+    aServices.Logger.LogOutputDump(lOutput.ToString, true);
 
 
   if n <> 0 then raise new Exception('Xcode failed');

--- a/RemObjects.Train/API/Xcode.pas
+++ b/RemObjects.Train/API/Xcode.pas
@@ -74,12 +74,11 @@ begin
       sb.Append(' SYMROOT="'+aServices.ResolveWithBase(ec,aOptions.destinationFolder)+'"');
     sb.Append(' '+aOptions.extraArgs);
   end;
-  //aServices.Logger.LogMessage(sb.ToString);
-
+  aServices.Logger.LogCommand('/usr/bin/xcodebuild', sb.ToString);
 
   var lOutput := new StringBuilder;
   var lErrors := new System.Collections.Generic.List<String>;
-  var n := Shell.ExecuteProcess('/usr/bin/xcodebuild', sb.ToString, nil,false ,
+  var lExitCode := Shell.ExecuteProcess('/usr/bin/xcodebuild', sb.ToString, nil,false ,
   a-> begin
     if not String.IsNullOrEmpty(a) then begin
       locking lErrors do lErrors.Add(a);
@@ -95,15 +94,15 @@ begin
     end;
    end, nil, nil);
 
-  if n <> 0 then begin
-    aServices.Logger.LogOutputDump(lOutput.ToString, false);
+  var lSuccess := (lExitCode = 0);
+  aServices.Logger.LogOutputDump(lOutput.ToString, lSuccess);
+  if not lSuccess then begin
     for each el in lErrors do
       aServices.Logger.LogError(el);
-  end else
-    aServices.Logger.LogOutputDump(lOutput.ToString, true);
+  end;
 
 
-  if n <> 0 then raise new Exception('Xcode failed');
+  if not lSuccess then raise new Exception('Xcode failed');
 
 end;
 

--- a/RemObjects.Train/DelayedLogger.pas
+++ b/RemObjects.Train/DelayedLogger.pas
@@ -21,6 +21,11 @@ type
     method LogDebug(s: String);
     method LogInfo(s: String);
     method LogLive(s: String); empty;
+    method Log(aKind: LogMessageKind; s: String);
+    method LogCommand(aExecutable: String; aArguments: String);
+    method LogCommandOutput(s: String);
+    method LogCommandOutputError(s: String);
+    method LogOutputDump(s: String; aSuccess: Boolean);
     method &Write; empty;
     property InIgnore: Boolean read fInIgnore write  set_InIgnore;
 
@@ -90,6 +95,11 @@ begin
       7: aTarget.Exit(true,lItem.Value.Item2, FailMode(lItem.Value.Item3), lItem.Value.Item4[0]);
       8: aTarget.LogInfo(lItem.Value.Item2);
       9: aTarget.InIgnore := Boolean(lItem.Value.Item3);
+      10: aTarget.Log(LogMessageKind(lItem.Value.Item3), lItem.Value.Item2);
+      11: aTarget.LogCommand(lItem.Value.Item2, String(lItem.Value.Item4[0]));
+      12: aTarget.LogCommandOutput(lItem.Value.Item2);
+      13: aTarget.LogCommandOutputError(lItem.Value.Item2);
+      14: aTarget.LogOutputDump(lItem.Value.Item2, lItem.Value.Item3 = 1);
     end;
     lItem := lItem.Next;
   end;
@@ -106,6 +116,36 @@ begin
   fInIgnore := value;
 
   fDelayStore.AddLast(Tuple.Create(9, '', if value then 1 else 0,array of Object(nil)));
+end;
+
+method DelayedLogger.Log(aKind: LogMessageKind; s: String);
+begin
+  locking fDelayStore do
+  fDelayStore.AddLast(Tuple.Create(10, s, Integer(aKind), array of Object(nil)));
+end;
+
+method DelayedLogger.LogCommand(aExecutable: String; aArguments: String);
+begin
+  locking fDelayStore do
+  fDelayStore.AddLast(Tuple.Create(11, aExecutable, 0, array of Object([aArguments])));
+end;
+
+method DelayedLogger.LogCommandOutput(s: String);
+begin
+  locking fDelayStore do
+  fDelayStore.AddLast(Tuple.Create(12, s, 0, array of Object(nil)));
+end;
+
+method DelayedLogger.LogCommandOutputError(s: String);
+begin
+  locking fDelayStore do
+  fDelayStore.AddLast(Tuple.Create(13, s, 0, array of Object(nil)));
+end;
+
+method DelayedLogger.LogOutputDump(s: String; aSuccess: Boolean);
+begin
+  locking fDelayStore do
+  fDelayStore.AddLast(Tuple.Create(14, s, if aSuccess then 1 else 0, array of Object(nil)));
 end;
 
 end.

--- a/Train/Program.pas
+++ b/Train/Program.pas
@@ -93,11 +93,13 @@ implementation
 
 method Logger.CleanedString(s: String): String;
 begin
-  var p := s.IndexOf(#10);
-  if p > 0 then
-    s := s.Substring(p)+"...";
-  s := s.Trim();
   // Don't truncate in debug mode - users need full paths and info when debugging
+  if not LoggerSettings.ShowDebug then begin
+    var p := s.IndexOf(#10);
+    if p > 0 then
+      s := s.Substring(p)+"...";
+  end;
+  s := s.Trim();
   if (not LoggerSettings.ShowDebug) and (length(s) > 50) then
     s := s.Substring(0, 50)+"...";
   for i: Int32 := 0 to length(s)-1 do

--- a/Train/Train.elements
+++ b/Train/Train.elements
@@ -12,7 +12,7 @@
     <AllowUnsafeCode>False</AllowUnsafeCode>
     <ApplicationIcon>Properties\App.ico</ApplicationIcon>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Name>Train</Name>
     <ProjectGuid>{BD3C0F3C-4943-488F-9886-4BC65FFE4DC4}</ProjectGuid>
   </PropertyGroup>


### PR DESCRIPTION
While debugging train scripts I made some changes that helped me do that debugging:

## Output

In the past, output was always truncated. I've left this for success (so the normal / happy path should be unchanged) but changed this for when something goes wrong, or when debugging.

* Errors now always print in full, never truncated
* If you run with `--debug`, both errors _and_ success outputs are always printed in full, never truncated.

This helped me solve errors, but also meant that when something was apparently working I was able to verify it truly was.

## Colors and Logging

Train already uses color in its output. I added:

* Coloring shell execution commands differently, so something that was run _by_ train was printed differently than something train was doing
* Expanded coloring in general, and expanded logging by type, so there is more nuance in what Log* methods are called. This means each kind of log could be formatted.
* General sort of changes in the sense of adding enums and some structure once I had expanded this, to keep it clean.

*Note:* Train also logs to XML output. I was worried about breaking CI analysis of XML results when I changed logging. A couple of things were never logged to XML (live command output, so streamed output was missed, just the final output) and so I added that. But many things go to XML in `<message>` tags, and rather than try to add new tags I kept that but added attributes: `<message kind="commandOutput" success="false">`, adding the kind and success attributes. This matched logging output and errors in colors onscreen.

* Live command output is now logged to XML as `<message kind="commandOutput">`
* Live stderr is logged as `<message kind="commandOutput" stream="stderr">`
* Command execution is logged as `<message kind="command">`
* Final output dumps are logged as `<message kind="output" success="true/false">` 

If I have any bug that breaks something, I think XML is where it is most likely to be. I examined it, asked AI to check it, both me and it think this is unlikely to break something, but... for code review / merging this is important to flag.

## Other

* Some missing locks in DelayedLogger, added
* The build tools (Delphi, MSBuild, EBuild, Xcode, shell) are where most of the attention has gone